### PR TITLE
add jboss.bridger.remove_existing_bridge_methods option

### DIFF
--- a/src/main/java/org/jboss/bridger/Bridger.java
+++ b/src/main/java/org/jboss/bridger/Bridger.java
@@ -161,7 +161,7 @@ public final class Bridger implements ClassFileTransformer {
         }
 
         public MethodVisitor visitMethod(final int access, final String name, final String desc, final String signature, final String[] exceptions) {
-            String removeExistingBridgeMethods = System.getProperty("jboss.bridger.remove_existing_bridge_methods");
+            boolean removeExistingBridgeMethods = Boolean.parseBoolean(System.getProperty("jboss.bridger.remove_existing_bridge_methods", "false"));
 
             final MethodVisitor defaultVisitor;
             final int idx = name.indexOf("$$bridge");
@@ -169,7 +169,7 @@ public final class Bridger implements ClassFileTransformer {
                 transformedMethodCount.getAndIncrement();
                 defaultVisitor = super.visitMethod(access | Opcodes.ACC_BRIDGE | Opcodes.ACC_SYNTHETIC, name.substring(0, idx), desc, signature, exceptions);
             } else {
-                if (removeExistingBridgeMethods != null && removeExistingBridgeMethods.equals("true") && (access & Opcodes.ACC_BRIDGE) != 0)
+                if (removeExistingBridgeMethods && (access & Opcodes.ACC_BRIDGE) != 0)
                     return null;
                 defaultVisitor = super.visitMethod(access, name, desc, signature, exceptions);
             }

--- a/src/main/java/org/jboss/bridger/Bridger.java
+++ b/src/main/java/org/jboss/bridger/Bridger.java
@@ -161,12 +161,16 @@ public final class Bridger implements ClassFileTransformer {
         }
 
         public MethodVisitor visitMethod(final int access, final String name, final String desc, final String signature, final String[] exceptions) {
+            String removeExistingBridgeMethods = System.getProperty("jboss.bridger.remove_existing_bridge_methods");
+
             final MethodVisitor defaultVisitor;
             final int idx = name.indexOf("$$bridge");
             if (idx != -1) {
                 transformedMethodCount.getAndIncrement();
                 defaultVisitor = super.visitMethod(access | Opcodes.ACC_BRIDGE | Opcodes.ACC_SYNTHETIC, name.substring(0, idx), desc, signature, exceptions);
             } else {
+                if (removeExistingBridgeMethods != null && removeExistingBridgeMethods.equals("true") && (access & Opcodes.ACC_BRIDGE) != 0)
+                    return null;
                 defaultVisitor = super.visitMethod(access, name, desc, signature, exceptions);
             }
             return new MethodVisitor(Opcodes.ASM4, defaultVisitor) {


### PR DESCRIPTION
I'd like to remove all the existing bridge methods in my class file. And then with the help of Bridge, I can replace them with my own implementations.