### PR TITLE
Ugrading to current ASM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>6.0</version>
+            <version>9.2</version>
         </dependency>
 
         <!-- maven plugin dependencies -->

--- a/src/main/java/org/jboss/bridger/Bridger.java
+++ b/src/main/java/org/jboss/bridger/Bridger.java
@@ -157,7 +157,7 @@ public final class Bridger implements ClassFileTransformer {
     private class TranslatingClassVisitor extends ClassVisitor {
 
         public TranslatingClassVisitor(final ClassWriter classWriter) {
-            super(Opcodes.ASM4, classWriter);
+            super(Opcodes.ASM9, classWriter);
         }
 
         public MethodVisitor visitMethod(final int access, final String name, final String desc, final String signature, final String[] exceptions) {
@@ -173,7 +173,7 @@ public final class Bridger implements ClassFileTransformer {
                     return null;
                 defaultVisitor = super.visitMethod(access, name, desc, signature, exceptions);
             }
-            return new MethodVisitor(Opcodes.ASM5, defaultVisitor) {
+            return new MethodVisitor(Opcodes.ASM9, defaultVisitor) {
                 public void visitInvokeDynamicInsn(final String name, final String desc, final Handle bsm, final Object... bsmArgs) {
                     final int idx = name.indexOf("$$bridge");
                     if (idx != -1) {


### PR DESCRIPTION
Hey @dmlloyd, this PR upgrades to the current version of ASM, allowing to use Bridger also with newer class files than 1.8.