### PR TITLE
Mark BridgerMojo as thread-safe for parallel Maven builds

### DIFF
--- a/src/main/java/org/jboss/bridger/BridgerMojo.java
+++ b/src/main/java/org/jboss/bridger/BridgerMojo.java
@@ -40,7 +40,7 @@ import org.codehaus.plexus.util.DirectoryScanner;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@Mojo(name = "transform", defaultPhase = LifecyclePhase.PROCESS_CLASSES)
+@Mojo(name = "transform", defaultPhase = LifecyclePhase.PROCESS_CLASSES, threadSafe = true)
 public class BridgerMojo extends AbstractMojo {
 
     /**


### PR DESCRIPTION
This prevents warnings like these in the build: 
```
[INFO] -------------------------< io.quarkus.arc:arc >-------------------------
[INFO] Building ArC - Runtime 999-SNAPSHOT                             [20/985]
[INFO]   from independent-projects/arc/runtime/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
Warning:  *****************************************************************
Warning:  * Your build is requesting parallel execution, but this         *
Warning:  * project contains the following plugin(s) that have goals not  *
Warning:  * marked as thread-safe to support parallel execution.          *
Warning:  * While this /may/ work fine, please look for plugin updates    *
Warning:  * and/or request plugins be made thread-safe.                   *
Warning:  * If reporting an issue, report it against the plugin in        *
Warning:  * question, not against Apache Maven.                           *
Warning:  *****************************************************************
Warning:  The following plugins are not marked as thread-safe in ArC - Runtime:
Warning:    org.jboss.bridger:bridger:1.6.Final
Warning:  
Warning:  Enable debug to see precisely which goals are not marked as thread-safe.
Warning:  *****************************************************************
```